### PR TITLE
Feature/vision values

### DIFF
--- a/Testing.md
+++ b/Testing.md
@@ -5,3 +5,4 @@
 1. Limelight LED defaults to off
 2. Limelight LED turns on when targeting
 3. Correct values for distance/vector to target display on shuffleboard
+4. Driver camera has live feed

--- a/Testing.md
+++ b/Testing.md
@@ -1,3 +1,7 @@
 # Version 0.1
 1. Move forward/backwards
 2. Left/Right turn
+# Version 0.2
+1. Limelight LED defaults to off
+2. Limelight LED turns on when targeting
+3. Correct values for distance/vector to target display on shuffleboard

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -16,4 +16,8 @@ package frc.robot;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
+    public static double groundToPowerPortIn = 98.75;
+    public static double groundToLimeLensIn = 26.8125;
+    public static double groundToLimeLensDeg = 26.5;
+    public static double groundToLimeLensRad = Math.toRadians(groundToLimeLensDeg);
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -16,8 +16,8 @@ package frc.robot;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
-    public static double groundToPowerPortIn = 98.75;
-    public static double groundToLimeLensIn = 26.8125;
-    public static double groundToLimeLensDeg = 26.5;
+    public static double groundToPowerPortIn = 98.25;
+    public static double groundToLimeLensIn = 27.25;
+    public static double groundToLimeLensDeg = 15;
     public static double groundToLimeLensRad = Math.toRadians(groundToLimeLensDeg);
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -8,6 +8,7 @@
 package frc.robot;
 
 import edu.wpi.first.cameraserver.CameraServer;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -29,11 +30,11 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
     CameraServer.getInstance().startAutomaticCapture();
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
-    m_robotContainer.turnLEDOff();
   }
 
   /**
@@ -57,10 +58,12 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void disabledInit() {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
   }
 
   @Override
   public void disabledPeriodic() {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
   }
 
   /**
@@ -68,7 +71,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
-    m_robotContainer.turnLEDOff();
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     // schedule the autonomous command (example)
@@ -87,7 +90,7 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopInit() {
     m_robotContainer.startTankDrive();
-    m_robotContainer.turnLEDOff();
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
     // This makes sure that the autonomous stops running when
     // teleop starts running. If you want the autonomous to
     // continue until interrupted by another command, remove

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -29,11 +29,11 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
-    m_robotContainer.turnLEDOff();
     CameraServer.getInstance().startAutomaticCapture();
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
+    m_robotContainer.turnLEDOff();
   }
 
   /**

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,6 +7,7 @@
 
 package frc.robot;
 
+import edu.wpi.first.cameraserver.CameraServer;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
@@ -28,6 +29,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
+    CameraServer.getInstance().startAutomaticCapture();
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -29,6 +29,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
+    m_robotContainer.turnLEDOff();
     CameraServer.getInstance().startAutomaticCapture();
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
@@ -67,6 +68,7 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void autonomousInit() {
+    m_robotContainer.turnLEDOff();
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     // schedule the autonomous command (example)
@@ -85,6 +87,7 @@ public class Robot extends TimedRobot {
   @Override
   public void teleopInit() {
     m_robotContainer.startTankDrive();
+    m_robotContainer.turnLEDOff();
     // This makes sure that the autonomous stops running when
     // teleop starts running. If you want the autonomous to
     // continue until interrupted by another command, remove

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -53,7 +53,7 @@ public class RobotContainer {
    */
   public RobotContainer() {
     // Configure the button bindings
-    driver2.whenPressed(new visionTarget(visionSensor), false);
+    driver2.whileHeld(new visionTarget(visionSensor), true);
     configureButtonBindings();
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -18,6 +18,7 @@ import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.commands.ExampleCommand;
 import frc.robot.commands.tankDrive;
 import frc.robot.commands.visionTarget;
+import frc.robot.commands.vLED;
 
 import frc.robot.subsystems.DriveBase;
 import frc.robot.subsystems.ExampleSubsystem;
@@ -45,6 +46,7 @@ public class RobotContainer {
 
   //OI Devices
   public static Joystick driver = new Joystick(0);
+  public static JoystickButton driver1 = new JoystickButton(driver, 1);
   public static JoystickButton driver2 = new JoystickButton(driver, 2);
 
 
@@ -53,7 +55,9 @@ public class RobotContainer {
    */
   public RobotContainer() {
     // Configure the button bindings
-    driver2.whileHeld(new visionTarget(visionSensor), true);
+    driver1.whenPressed(new vLED(visionSensor, true), false);
+    driver1.whenReleased(new vLED(visionSensor, false), false);
+    driver2.whileHeld(new visionTarget(visionSensor), false);
     configureButtonBindings();
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -14,11 +14,17 @@ import com.ctre.phoenix.motorcontrol.can.VictorSPX;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
+
 import frc.robot.commands.ExampleCommand;
 import frc.robot.commands.tankDrive;
+import frc.robot.commands.visionTarget;
+
 import frc.robot.subsystems.DriveBase;
 import frc.robot.subsystems.ExampleSubsystem;
+import frc.robot.subsystems.limeLight;
+
 import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
 /**
  * This class is where the bulk of the robot should be declared.  Since Command-based is a
@@ -28,13 +34,18 @@ import edu.wpi.first.wpilibj2.command.Command;
  */
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
+  //Subsytems
   private final ExampleSubsystem m_exampleSubsystem = new ExampleSubsystem();
   private final DriveBase driveBase = new DriveBase();
+  private final limeLight visionSensor = new limeLight();
 
+  //Commands
   private final ExampleCommand m_autoCommand = new ExampleCommand(m_exampleSubsystem);
   private final tankDrive mainDrive = new tankDrive(driveBase);
 
+  //OI Devices
   public static Joystick driver = new Joystick(0);
+  public static JoystickButton driver2 = new JoystickButton(driver, 2);
 
 
   /**
@@ -42,6 +53,7 @@ public class RobotContainer {
    */
   public RobotContainer() {
     // Configure the button bindings
+    driver2.whenPressed(new visionTarget(visionSensor), false);
     configureButtonBindings();
   }
 
@@ -63,7 +75,7 @@ public class RobotContainer {
   public Command getAutonomousCommand() {
     // An ExampleCommand will run in autonomous
     return m_autoCommand;
-  }
+  } 
 
   public void startTankDrive()
   {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -82,6 +82,11 @@ public class RobotContainer {
     mainDrive.schedule(true);
   }
 
+  public void turnLEDOff()
+  {
+    visionSensor.vLEDoff();
+  }
+
   public static void initMotor(TalonSRX motor, double peak)
   {
     motor.configPeakOutputForward(peak);

--- a/src/main/java/frc/robot/commands/ExampleCommand.java
+++ b/src/main/java/frc/robot/commands/ExampleCommand.java
@@ -15,7 +15,7 @@ import edu.wpi.first.wpilibj2.command.CommandBase;
  */
 public class ExampleCommand extends CommandBase {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final ExampleSubsystem m_subsystem;
+  //private final ExampleSubsystem m_subsystem; // Commented out to suppress warning
 
   /**
    * Creates a new ExampleCommand.
@@ -23,7 +23,7 @@ public class ExampleCommand extends CommandBase {
    * @param subsystem The subsystem used by this command.
    */
   public ExampleCommand(ExampleSubsystem subsystem) {
-    m_subsystem = subsystem;
+    //m_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }

--- a/src/main/java/frc/robot/commands/vLED.java
+++ b/src/main/java/frc/robot/commands/vLED.java
@@ -1,0 +1,57 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.limeLight;
+
+public class vLED extends CommandBase {
+  private limeLight limeL;
+  private boolean start;
+  /**
+   * Creates a new vLED.
+   * 
+   * @param LimeL The limelight to use, should only be one
+   * @param Start True if the light to be turned on, false if light should be off
+   */
+  public vLED(limeLight LimeL, boolean Start) {
+    limeL = LimeL;
+    start = Start; 
+    addRequirements(LimeL);
+    // Use addRequirements() here to declare subsystem dependencies.
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    if(start)
+    {
+    limeL.vLEDon();
+    }
+    else
+    {
+      limeL.vLEDoff();
+    }
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/visionTarget.java
+++ b/src/main/java/frc/robot/commands/visionTarget.java
@@ -1,0 +1,57 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+import frc.robot.subsystems.limeLight;
+
+public class visionTarget extends CommandBase {
+  private limeLight limeL;
+  private double distanceToPowerPort;
+  private double xValueOff;
+  /**
+   * Creates a new visionTarget.
+   * 
+   * @param plimeL The limeLight to pass to this command
+   */
+  public visionTarget(limeLight plimeL) 
+  {
+    limeL = plimeL;
+    addRequirements(plimeL);
+    // Use addRequirements() here to declare subsystem dependencies.
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {
+    limeL.visionStoreValues();
+    distanceToPowerPort = limeL.getDistance(Constants.groundToLimeLensIn, Constants.groundToPowerPortIn, Constants.groundToLimeLensRad);
+    xValueOff = limeL.getXValueOff();
+    SmartDashboard.putNumber("Distance to power port", distanceToPowerPort);
+    SmartDashboard.putNumber("Vector to inner port", xValueOff);
+  }
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {
+    limeL.vLEDoff();
+  }
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/visionTarget.java
+++ b/src/main/java/frc/robot/commands/visionTarget.java
@@ -52,6 +52,6 @@ public class visionTarget extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return true;
+    return false;
   }
 }

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -32,8 +32,8 @@ public class DriveBase extends SubsystemBase {
     backRightDrive = new VictorSPX(4);
     backLeftDrive.follow(frontLeftDrive);
     backRightDrive.follow(frontRightDrive);
-    frontRightDrive.setInverted(true);
-    backRightDrive.setInverted(true);
+    frontLeftDrive.setInverted(true);
+    backLeftDrive.setInverted(true);
     RobotContainer.initMotor(frontLeftDrive, peak);
     RobotContainer.initMotor(frontRightDrive, peak);
     RobotContainer.initMotor(backLeftDrive, peak);

--- a/src/main/java/frc/robot/subsystems/limeLight.java
+++ b/src/main/java/frc/robot/subsystems/limeLight.java
@@ -20,6 +20,7 @@ public class limeLight extends SubsystemBase {
    * Creates a new limeLight.
    */
   public limeLight() {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
     yValueOff = 0;
     xValueOff = 0;
   }
@@ -33,11 +34,18 @@ public class limeLight extends SubsystemBase {
   }
 
   /**
+   * Turns the limelight's LEDs on
+   */
+  public void vLEDon()
+  {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(3);
+  }
+
+  /**
    * 
    */
   public void visionStoreValues()
   {
-    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(3);
     NetworkTable table = NetworkTableInstance.getDefault().getTable("limelight");
     NetworkTableEntry ty = table.getEntry("ty");
     NetworkTableEntry tx = table.getEntry("tx");
@@ -73,7 +81,7 @@ public class limeLight extends SubsystemBase {
    */
   public double getDistance(double h1, double h2, double a1)
   {
-    return (h2 - h1)/java.lang.Math.tan(a1+Math.toRadians(yValueOff));
+    return (h2 - h1)/(Math.tan(a1+Math.toRadians(yValueOff)));
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/limeLight.java
+++ b/src/main/java/frc/robot/subsystems/limeLight.java
@@ -20,7 +20,6 @@ public class limeLight extends SubsystemBase {
    * Creates a new limeLight.
    */
   public limeLight() {
-    vLEDoff();
     yValueOff = 0;
     xValueOff = 0;
   }

--- a/src/main/java/frc/robot/subsystems/limeLight.java
+++ b/src/main/java/frc/robot/subsystems/limeLight.java
@@ -1,0 +1,84 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.subsystems;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.NetworkTableEntry;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+
+public class limeLight extends SubsystemBase {
+  private double xValueOff;
+  private double yValueOff;
+  /**
+   * Creates a new limeLight.
+   */
+  public limeLight() {
+    vLEDoff();
+    yValueOff = 0;
+    xValueOff = 0;
+  }
+
+  /**
+   * Turns the limelight's LEDs off
+   */
+  public void vLEDoff()
+  {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(1);
+  }
+
+  /**
+   * 
+   */
+  public void visionStoreValues()
+  {
+    NetworkTableInstance.getDefault().getTable("limelight").getEntry("ledMode").setNumber(3);
+    NetworkTable table = NetworkTableInstance.getDefault().getTable("limelight");
+    NetworkTableEntry ty = table.getEntry("ty");
+    NetworkTableEntry tx = table.getEntry("tx");
+    xValueOff = tx.getDouble(0);
+    yValueOff = ty.getDouble(0);
+  }
+
+  /**
+   * 
+   * @return Returns X value off of last recorded vision target
+   */
+  public double getXValueOff()
+  {
+    return xValueOff;
+  }
+
+   /**
+   * 
+   * @return Returns Y value off of last recorded vision target
+   */
+  public double getYValueOff()
+  {
+    return yValueOff;
+  }
+
+  /**
+   * Runs vision targeting to determine distance from target
+   * 
+   * @param h1 Disatnce from ground to camera's lens
+   * @param h2 Distance from ground to target
+   * @param a1 Angle, degrees, from ground to camera lens
+   * @return Distance from the camera lens to the target
+   */
+  public double getDistance(double h1, double h2, double a1)
+  {
+    return (h2 - h1)/java.lang.Math.tan(a1+Math.toRadians(yValueOff));
+  }
+
+  @Override
+  public void periodic() {
+    // This method will be called once per scheduler run
+  }
+}


### PR DESCRIPTION
Added vision values for v0.2, can now calculate distance to target with a maximum error of +-2 in, at ~20 ft. Negligible error at 15+ft. Vector to center of target gives correct value. LED turns off after initial startup, and turns on with the 'x' button. While LED is on, 'a' will give the aforementioned values on shuffle board. 